### PR TITLE
Adds several major changes to the defined scalar types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1232,11 +1232,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "graphql": "^15.0.0",
-    "bignumber.js": "^9.0.0",
     "@jest/globals": "^26.0.1"
   },
   "devDependencies": {

--- a/src/scalars/GraphQLDecimal.js
+++ b/src/scalars/GraphQLDecimal.js
@@ -1,11 +1,9 @@
 import {GraphQLError, GraphQLScalarType, Kind} from "graphql";
 import {isNumber, throwConversionError} from "./Utilities";
-import {BigNumber} from "bignumber.js";
 
 function convert(value) {
     if (isNumber(value)) {
-        let bigNumber = new BigNumber(value);
-        return bigNumber.toPrecision(bigNumber.sd(true), BigNumber.ROUND_HALF_UP);
+        return value + '';
     }
 
     throw new GraphQLError(`Expected 'Decimal' value, but got ${value}`);
@@ -29,11 +27,6 @@ export default new GraphQLScalarType({
             throwConversionError(type, this.name);
         }
 
-        let value = node.value;
-        if (!isNumber(value)) {
-            throw new GraphQLError(`Expected '${this.name}' value, but got '${value}'`);
-        }
-
-        return new BigNumber(value);
+        return convert(node.value);
     }
 });

--- a/src/scalars/GraphQLInteger.js
+++ b/src/scalars/GraphQLInteger.js
@@ -1,6 +1,5 @@
 import {GraphQLError, GraphQLScalarType, Kind} from "graphql";
-import {BigNumber} from "bignumber.js";
-import {parseAsBigNumber, throwConversionError} from "./Utilities";
+import {parseAsBigNumber, throwConversionError, isInteger} from "./Utilities";
 
 /**
  * Defines custom GraphQLScalarType for Integer values.
@@ -24,9 +23,9 @@ export default new GraphQLScalarType({
             throwConversionError(kind, this.name);
         }
 
-        let value = new BigNumber(node.value);
-        if (value.isInteger()) {
-            return value;
+        let value = node.value;
+        if (isInteger(value)) {
+            return value + '';
         }
 
         throw new GraphQLError(`Expected '${this.name}' value, but got '${value}'`);

--- a/src/scalars/GraphQLNegativeFloat.js
+++ b/src/scalars/GraphQLNegativeFloat.js
@@ -1,23 +1,32 @@
 import {GraphQLError, GraphQLFloat, GraphQLScalarType} from "graphql";
 
+const NEGATIVE_FLOAT = 'NegativeFloat';
+
+function convert(value) {
+    if (value >= 0) {
+        throw new GraphQLError(`The value of '${NEGATIVE_FLOAT}' should be negative, below zero.`);
+    }
+
+    return value + '';
+}
+
 /**
  * Defines custom GraphQLScalarType for negative float values.
  */
 export default new GraphQLScalarType({
-    name: `NegativeFloat`,
+    name: NEGATIVE_FLOAT,
 
     description: `An Float scalar that must be a negative value`,
 
-    serialize: GraphQLFloat.serialize,
+    serialize(value) {
+        return convert(GraphQLFloat.serialize(value));
+    },
 
-    parseValue: GraphQLFloat.parseValue,
+    parseValue(value) {
+     return convert(GraphQLFloat.parseValue(value));
+    },
 
     parseLiteral(node) {
-        let value = GraphQLFloat.parseLiteral(node);
-        if (value >= 0) {
-            throw new GraphQLError(`The value of '${this.name}' should be negative, below zero.`);
-        }
-
-        return value;
+        return convert(GraphQLFloat.parseLiteral(node));
     }
 });

--- a/src/scalars/GraphQLNegativeInteger.js
+++ b/src/scalars/GraphQLNegativeInteger.js
@@ -1,6 +1,5 @@
 import {GraphQLError, GraphQLScalarType, Kind} from "graphql";
-import {BigNumber} from "bignumber.js";
-import {parseAsBigNumber, throwConversionError} from "./Utilities";
+import {parseAsBigNumber, throwConversionError, isInteger, isPositive} from "./Utilities";
 
 /**
  * Defines custom GraphQLScalarType for negative Integer values.
@@ -24,15 +23,15 @@ export default new GraphQLScalarType({
             throwConversionError(kind, this.name);
         }
 
-        let value = new BigNumber(node.value);
-        if (!value.isInteger()) {
+        let value = node.value;
+        if (!isInteger(value)) {
             throw new GraphQLError(`Expected '${this.name}', but got '${value}'.`);
         }
 
-        if (!value.isNegative() || value.eq(0)) {
+        if (isPositive(value) || value === 0) {
             throw new GraphQLError(`The value of '${this.name}' should be negative, below zero.`);
         }
 
-        return value;
+        return value + '';
     }
 });

--- a/src/scalars/GraphQLNonNegativeFloat.js
+++ b/src/scalars/GraphQLNonNegativeFloat.js
@@ -1,23 +1,32 @@
 import {GraphQLError, GraphQLFloat, GraphQLScalarType} from "graphql";
 
+const NON_NEGATIVE_FLOAT = 'NonNegativeFloat';
+
+function convert(value) {
+    if (value < 0) {
+        throw new GraphQLError(`The value of '${NON_NEGATIVE_FLOAT}' should be positive or zero.`);
+    }
+
+    return value + '';
+}
+
 /**
  * Defines custom GraphQLScalarType for non negative float values.
  */
 export default new GraphQLScalarType({
-    name: `NonNegativeFloat`,
+    name: NON_NEGATIVE_FLOAT,
 
     description: `An Float scalar that must be greater than or equal to zero`,
 
-    serialize: GraphQLFloat.serialize,
+    serialize(value) {
+        return convert(GraphQLFloat.serialize(value));
+    },
 
-    parseValue: GraphQLFloat.parseValue,
+    parseValue(value) {
+        return convert(GraphQLFloat.parseValue(value));
+    },
 
     parseLiteral(node) {
-        let value = GraphQLFloat.parseLiteral(node);
-        if (value < 0) {
-            throw new GraphQLError(`The value of '${this.name}' should be positive or zero.`);
-        }
-
-        return value;
+        return convert(GraphQLFloat.parseLiteral(node));
     }
 });

--- a/src/scalars/GraphQLNonNegativeInteger.js
+++ b/src/scalars/GraphQLNonNegativeInteger.js
@@ -1,6 +1,5 @@
 import {GraphQLError, GraphQLScalarType, Kind} from "graphql";
-import {BigNumber} from "bignumber.js";
-import {parseAsBigNumber, throwConversionError} from "./Utilities";
+import {isInteger, isNegative, parseAsBigNumber, throwConversionError} from "./Utilities";
 
 /**
  * Defines custom GraphQLScalarType for non negative Integer values.
@@ -24,15 +23,15 @@ export default new GraphQLScalarType({
             throwConversionError(kind, this.name);
         }
 
-        let value = new BigNumber(node.value);
-        if (!value.isInteger()) {
+        let value = node.value;
+        if (!isInteger(value)) {
             throw new GraphQLError(`Expected '${this.name}', but got '${value}'.`);
         }
 
-        if (value.isNegative() && !value.eq(0)) {
+        if (isNegative(value) && value !== 0) {
             throw new GraphQLError(`The value of '${this.name}' should be positive or zero.`);
         }
 
-        return value;
+        return value + '';
     }
 });

--- a/src/scalars/GraphQLNonPositiveFloat.js
+++ b/src/scalars/GraphQLNonPositiveFloat.js
@@ -1,23 +1,32 @@
 import {GraphQLError, GraphQLFloat, GraphQLScalarType} from "graphql";
 
+const NON_POSITIVE_FLOAT = 'NonPositiveFloat';
+
+function convert(value) {
+    if (value > 0) {
+        throw new GraphQLError(`The value of '${NON_POSITIVE_FLOAT}' should be negative or zero.`);
+    }
+
+    return value + '';
+}
+
 /**
  * Defines custom GraphQLScalarType for non positive float values.
  */
 export default new GraphQLScalarType({
-    name: `NonPositiveFloat`,
+    name: NON_POSITIVE_FLOAT,
 
     description: `An Float scalar that must be less than or equal to zero`,
 
-    serialize: GraphQLFloat.serialize,
+    serialize(value) {
+        return convert(GraphQLFloat.serialize(value));
+    },
 
-    parseValue: GraphQLFloat.parseValue,
+    parseValue(value) {
+        return convert(GraphQLFloat.parseValue(value));
+    },
 
     parseLiteral(node) {
-        let value = GraphQLFloat.parseLiteral(node);
-        if (value > 0) {
-            throw new GraphQLError(`The value of '${this.name}' should be negative or zero.`);
-        }
-
-        return value;
+        return convert(GraphQLFloat.parseLiteral(node));
     }
 });

--- a/src/scalars/GraphQLNonPositiveInteger.js
+++ b/src/scalars/GraphQLNonPositiveInteger.js
@@ -1,6 +1,5 @@
 import {GraphQLError, GraphQLScalarType, Kind} from "graphql";
-import {BigNumber} from "bignumber.js";
-import {parseAsBigNumber, throwConversionError} from "./Utilities";
+import {isInteger, isPositive, parseAsBigNumber, throwConversionError} from "./Utilities";
 
 /**
  * Defines custom GraphQLScalarType for non positive Integer values.
@@ -24,15 +23,15 @@ export default new GraphQLScalarType({
             throwConversionError(kind, this.name);
         }
 
-        let value = new BigNumber(node.value);
-        if (!value.isInteger()) {
+        let value = node.value;
+        if (!isInteger(value)) {
             throw new GraphQLError(`Expected '${this.name}', but got '${value}'.`);
         }
 
-        if (!value.isNegative() && !value.eq(0)) {
+        if (isPositive(value) && value !== 0) {
             throw new GraphQLError(`The value of '${this.name}' should be negative or zero.`);
         }
 
-        return value;
+        return value + '';
     }
 });

--- a/src/scalars/GraphQLPositiveFloat.js
+++ b/src/scalars/GraphQLPositiveFloat.js
@@ -1,24 +1,33 @@
 import {GraphQLFloat, GraphQLScalarType} from "graphql";
 import {throwNegativeValueError} from "./Utilities";
 
+const POSITIVE_FLOAT = 'PositiveFloat';
+
+function convert(value) {
+    if (value <= 0) {
+        throwNegativeValueError(value, POSITIVE_FLOAT);
+    }
+
+    return value + '';
+}
+
 /**
  * Defines custom GraphQLScalarType for positive float values.
  */
 export default new GraphQLScalarType({
-    name: `PositiveFloat`,
+    name: POSITIVE_FLOAT,
 
     description: `An Float scalar that must be a positive value`,
 
-    serialize: GraphQLFloat.serialize,
+    serialize(value) {
+        return convert(GraphQLFloat.serialize(value));
+    },
 
-    parseValue: GraphQLFloat.parseValue,
+    parseValue(value) {
+        return convert(GraphQLFloat.parseValue(value));
+    },
 
     parseLiteral(node) {
-        let value = GraphQLFloat.parseLiteral(node);
-        if (value <= 0) {
-            throwNegativeValueError(value, this.name);
-        }
-
-        return value;
+        return convert(GraphQLFloat.parseLiteral(node));
     }
 });

--- a/src/scalars/GraphQLPositiveInteger.js
+++ b/src/scalars/GraphQLPositiveInteger.js
@@ -1,6 +1,5 @@
 import {GraphQLError, GraphQLScalarType, Kind} from "graphql";
-import {BigNumber} from "bignumber.js";
-import {parseAsBigNumber, throwConversionError} from "./Utilities";
+import {isInteger, isNegative, parseAsBigNumber, throwConversionError} from "./Utilities";
 
 /**
  * Defines custom GraphQLScalarType for positive Integer values.
@@ -24,15 +23,15 @@ export default new GraphQLScalarType({
             throwConversionError(kind, this.name);
         }
 
-        let value = new BigNumber(node.value);
-        if (!value.isInteger()) {
+        let value = node.value;
+        if (!isInteger(value)) {
             throw new GraphQLError(`Expected '${this.name}' value, but got '${value}'`);
         }
 
-        if (value.isNegative() || value.eq(0)) {
+        if (isNegative(value) || value === 0) {
             throw new GraphQLError(`The value of '${this.name}' should be positive, above zero.`);
         }
 
-        return value;
+        return value + '';
     }
 });

--- a/src/scalars/time/GraphQLYear.js
+++ b/src/scalars/time/GraphQLYear.js
@@ -1,35 +1,40 @@
 import {GraphQLError, GraphQLScalarType, Kind} from "graphql";
 import {throwConversionError} from "../Utilities";
 
+const YEAR = 'Year';
 const YEAR_REGEX = /-?\d{4,}(Z|([+-])\d\d:\d\d)?/;
 
 function validateYear(year) {
     if (!YEAR_REGEX.test(year)) {
-        throw new GraphQLError(`Invalid value for 'Year' - '${year}'`);
+        throw new GraphQLError(`Invalid value for '${YEAR}' - '${year}'`);
     }
+}
+
+function getYearAsStr(date) {
+    return date.getFullYear().toString();
 }
 
 /**
  * Defines custom GraphQLScalarType for RFC-3339 compliant year values.
  */
 export default new GraphQLScalarType({
-    name: `Year`,
+    name: YEAR,
 
     description: `An RFC-3339 compliant Year Scalar`,
 
     serialize(value) {
         if (value instanceof Date) {
-            return value.getFullYear();
+            return getYearAsStr(value);
         } else if (typeof value === 'string' || value instanceof String) {
             if (!isNaN(Date.parse(value))) {
-                return new Date(value).getFullYear();
+                return getYearAsStr(new Date(value));
             }
 
             validateYear(value);
-            return value;
+            return value.toString();
         }
 
-        throw new GraphQLError(`Expected '${this.name}' value, but got '${JSON.stringify(value)}'.`);
+        throw new GraphQLError(`Expected '${YEAR}' value, but got '${JSON.stringify(value)}'.`);
     },
 
     parseValue(value) {
@@ -38,12 +43,12 @@ export default new GraphQLScalarType({
             return value;
         }
 
-        throw new GraphQLError(`Expected value in '${this.name}' format, but got '${JSON.stringify(value)}'.`);
+        throw new GraphQLError(`Expected value in '${YEAR}' format, but got '${JSON.stringify(value)}'.`);
     },
 
     parseLiteral(node) {
         if (node.kind !== Kind.STRING) {
-            throwConversionError(node.kind, this.name);
+            throwConversionError(node.kind, YEAR);
         }
 
         let value = node.value;

--- a/src/scalars/unsigned/GraphQLUnsignedByte.js
+++ b/src/scalars/unsigned/GraphQLUnsignedByte.js
@@ -1,8 +1,8 @@
 import {GraphQLScalarType} from "graphql";
-import {parseAsInt, parseUnsignedLiteral} from "../Utilities";
+import {parseUnsignedValue, parseUnsignedLiteral} from "../Utilities";
 
 // defines max values allowed for the current type
-const MAX_VALUE = Math.pow(2, 8);
+const MAX_VALUE = Math.pow(2, 8) -1;
 
 /**
  * Defines custom GraphQLScalarType for unsigned byte values.
@@ -13,11 +13,11 @@ export default new GraphQLScalarType({
     description: `Unsigned 8-bit integer`,
 
     serialize(value) {
-        return parseAsInt(value, this.name);
+        return parseUnsignedValue(value, MAX_VALUE, this.name);
     },
 
     parseValue(value) {
-        return parseAsInt(value, this.name);
+        return parseUnsignedValue(value, MAX_VALUE, this.name);
     },
 
     parseLiteral(node) {

--- a/src/scalars/unsigned/GraphQLUnsignedInteger.js
+++ b/src/scalars/unsigned/GraphQLUnsignedInteger.js
@@ -1,8 +1,8 @@
 import {GraphQLScalarType} from "graphql";
-import {parseAsInt, parseUnsignedLiteral} from "../Utilities";
+import {parseUnsignedValue, parseUnsignedLiteral} from "../Utilities";
 
 // defines max values allowed for the current type
-const MAX_VALUE = Math.pow(2, 32);
+const MAX_VALUE = Math.pow(2, 32) -1;
 
 /**
  * Defines custom GraphQLScalarType for unsigned Integer values.
@@ -13,11 +13,11 @@ export default new GraphQLScalarType({
     description: `Unsigned 32-bit integer`,
 
     serialize(value) {
-        return parseAsInt(value, this.name);
+        return parseUnsignedValue(value, MAX_VALUE, this.name);
     },
 
     parseValue(value) {
-        return parseAsInt(value, this.name);
+        return parseUnsignedValue(value, MAX_VALUE, this.name);
     },
 
     parseLiteral(node) {

--- a/src/scalars/unsigned/GraphQLUnsignedLong.js
+++ b/src/scalars/unsigned/GraphQLUnsignedLong.js
@@ -1,23 +1,76 @@
 import {GraphQLError, GraphQLScalarType, Kind} from "graphql";
-import {isNumber, throwConversionError, throwNegativeValueError, throwOutOfRangeError} from "../Utilities";
-import {BigNumber} from "bignumber.js";
+import {
+    isInteger,
+    isNegative,
+    isNumber,
+    throwConversionError,
+    throwNegativeValueError,
+    throwOutOfRangeError
+} from "../Utilities";
 
-// defines max values allowed for the current type
-const MAX_VALUE = new BigNumber(Math.pow(2, 64));
+const UNSIGNED_LONG = 'UnsignedLong';
+
+// defines max values allowed for the current type - 2^64 -1
+const MAX_VALUE_ARRAY = Array.from('18446744073709551615', Number);
+
 
 function convert(value) {
-    if (isNumber(value)) {
-        return new BigNumber(value).integerValue(BigNumber.ROUND_HALF_UP).toString();
+    if (!isNumber(value)) {
+        throw new GraphQLError(`Expected number, but got '${value}'`);
     }
 
-    throw new GraphQLError(`Expected 'UnsignedLong' value, but got ${JSON.stringify(value)}`);
+    let copy = value;
+    if (!isInteger(copy)) {
+        copy = Math.trunc(copy);
+    }
+
+    if (isNegative(copy)) {
+        throwNegativeValueError(value, UNSIGNED_LONG);
+    }
+
+    if (checkOutOfRange(copy)) {
+        throwOutOfRangeError(value, UNSIGNED_LONG);
+    }
+
+    return copy + '';
+}
+
+function checkOutOfRange(value) {
+    let valueArray = Array.from(BigInt(value).toString(), Number);
+    if(valueArray.length < MAX_VALUE_ARRAY.length) {
+        return false;
+    }
+
+    if(valueArray.length > MAX_VALUE_ARRAY.length) {
+        return  true;
+    }
+
+    // the lengths are equal here so we need to check the actual values
+    for (let idx = 0; idx < MAX_VALUE_ARRAY.length; idx++) {
+        let maxValueNum = MAX_VALUE_ARRAY[idx];
+        let valueNum = valueArray[idx];
+        // if the number at that position is less then the max number, the whole value should be OK
+        if(maxValueNum > valueNum) {
+            return false;
+        }
+
+        // if the value number is greater then the max number, the whole value exceeds the limit
+        if(maxValueNum < valueNum) {
+            return true;
+        }
+
+        // continue with the next number as the max number and the value number are equal at this point
+    }
+
+    // the value is equal to the max allowed
+    return false;
 }
 
 /**
  * Defines custom GraphQLScalarType for unsigned Long values.
  */
 export default new GraphQLScalarType({
-    name: `UnsignedLong`,
+    name: UNSIGNED_LONG,
 
     description: `Unsigned 64-bit integer`,
 
@@ -28,18 +81,9 @@ export default new GraphQLScalarType({
     parseLiteral(node) {
         let type = node.kind;
         if (Kind.INT !== type && Kind.STRING !== type) {
-            throwConversionError(type, this.name);
+            throwConversionError(type, UNSIGNED_LONG);
         }
 
-        let value = new BigNumber(node.value);
-        if (value.isNegative()) {
-            throwNegativeValueError(value, this.name);
-        }
-
-        if (MAX_VALUE.isLessThan(value)) {
-            throwOutOfRangeError(value, this.name);
-        }
-
-        return value.integerValue(BigNumber.ROUND_HALF_UP);
+        return convert(node.value);
     }
 });

--- a/src/scalars/unsigned/GraphQLUnsignedShort.js
+++ b/src/scalars/unsigned/GraphQLUnsignedShort.js
@@ -1,8 +1,8 @@
 import {GraphQLScalarType} from "graphql";
-import {parseAsInt, parseUnsignedLiteral} from "../Utilities";
+import {parseUnsignedValue, parseUnsignedLiteral} from "../Utilities";
 
 // defines max values allowed for the current type
-const MAX_VALUE = Math.pow(2, 16);
+const MAX_VALUE = Math.pow(2, 16) -1;
 
 /**
  * Defines custom GraphQLScalarType for unsigned short values.
@@ -13,11 +13,11 @@ export default new GraphQLScalarType({
     description: `Unsigned 16-bit integer`,
 
     serialize(value) {
-        return parseAsInt(value, this.name);
+        return parseUnsignedValue(value, MAX_VALUE, this.name);
     },
 
     parseValue(value) {
-        return parseAsInt(value, this.name);
+        return parseUnsignedValue(value, MAX_VALUE, this.name);
     },
 
     parseLiteral(node) {

--- a/test/GraphQLDecimal.test.js
+++ b/test/GraphQLDecimal.test.js
@@ -1,7 +1,6 @@
 import {describe, expect, test} from "@jest/globals";
 import GraphQLDecimal from "../src/scalars/GraphQLDecimal";
 import {Kind} from "graphql";
-import BigNumber from "bignumber.js";
 
 describe(`GraphQLDecimal`, () => {
 
@@ -45,7 +44,7 @@ describe(`GraphQLDecimal`, () => {
 
             test(`negative string`, () => expect(GraphQLDecimal.parseValue('-100.44')).toEqual('-100.44'));
 
-            test(`large string`, () => expect(GraphQLDecimal.parseValue('10000000000.12600000000')).toEqual('10000000000.126'));
+            test(`large string`, () => expect(GraphQLDecimal.parseValue('10000000000.12600000000')).toEqual('10000000000.12600000000'));
 
             test(`number`, () => expect(GraphQLDecimal.parseValue(100000.999)).toEqual('100000.999'));
 
@@ -75,17 +74,17 @@ describe(`GraphQLDecimal`, () => {
             test(`string`, () => expect(GraphQLDecimal.parseLiteral({
                 kind: Kind.STRING,
                 value: '123123'
-            })).toEqual(BigNumber(123123)));
+            })).toEqual('123123'));
 
             test(`integer`, () => expect(GraphQLDecimal.parseLiteral({
                 kind: Kind.INT,
                 value: 123123
-            })).toEqual(BigNumber(123123)));
+            })).toEqual('123123'));
 
             test(`float`, () => expect(GraphQLDecimal.parseLiteral({
                 kind: Kind.FLOAT,
                 value: 12.3123
-            })).toEqual(BigNumber(12.3123)));
+            })).toEqual('12.3123'));
         });
 
         describe(`invalid`, () => {

--- a/test/GraphQLInteger.test.js
+++ b/test/GraphQLInteger.test.js
@@ -1,7 +1,6 @@
 import {describe, expect, test} from "@jest/globals";
 import GraphQLInteger from "../src/scalars/GraphQLInteger";
 import {Kind} from "graphql";
-import BigNumber from "bignumber.js";
 
 describe(`GraphQLInteger`, () => {
 
@@ -75,12 +74,12 @@ describe(`GraphQLInteger`, () => {
             test(`string`, () => expect(GraphQLInteger.parseLiteral({
                 kind: Kind.STRING,
                 value: '123123'
-            })).toEqual(BigNumber(123123)));
+            })).toEqual('123123'));
 
             test(`integer`, () => expect(GraphQLInteger.parseLiteral({
                 kind: Kind.INT,
                 value: 123123
-            })).toEqual(BigNumber(123123)));
+            })).toEqual('123123'));
         });
 
         describe(`invalid`, () => {

--- a/test/GraphQLNegativeFloat.test.js
+++ b/test/GraphQLNegativeFloat.test.js
@@ -11,12 +11,12 @@ describe(`GraphQLNegativeFloat`, () => {
             test(`int`, () => expect(GraphQLNegativeFloat.parseLiteral({
                 kind: Kind.INT,
                 value: -123
-            })).toEqual(-123));
+            })).toEqual('-123'));
 
             test(`float`, () => expect(GraphQLNegativeFloat.parseLiteral({
                 kind: Kind.FLOAT,
                 value: -123.123
-            })).toEqual(-123.123));
+            })).toEqual('-123.123'));
         });
 
         describe(`invalid`, () => {

--- a/test/GraphQLNegativeInteger.test.js
+++ b/test/GraphQLNegativeInteger.test.js
@@ -1,7 +1,6 @@
 import {describe, expect, test} from "@jest/globals";
 import GraphQLNegativeInteger from "../src/scalars/GraphQLNegativeInteger";
 import {Kind} from "graphql";
-import BigNumber from "bignumber.js";
 
 describe(`GraphQLNegativeInteger`, () => {
 
@@ -68,17 +67,17 @@ describe(`GraphQLNegativeInteger`, () => {
             test(`int`, () => expect(GraphQLNegativeInteger.parseLiteral({
                 kind: Kind.STRING,
                 value: '-123'
-            })).toEqual(new BigNumber(-123)));
+            })).toEqual('-123'));
 
             test(`int`, () => expect(GraphQLNegativeInteger.parseLiteral({
                 kind: Kind.INT,
                 value: -123
-            })).toEqual(new BigNumber(-123)));
+            })).toEqual('-123'));
 
             test(`large number`, () => expect(GraphQLNegativeInteger.parseLiteral({
                 kind: Kind.INT,
-                value: -123123123123123123
-            })).toEqual(new BigNumber(-123123123123123123)));
+                value: '-123123123123123123'
+            })).toEqual('-123123123123123123'));
         });
 
         describe(`invalid`, () => {

--- a/test/GraphQLNonNegativeFloat.test.js
+++ b/test/GraphQLNonNegativeFloat.test.js
@@ -11,17 +11,17 @@ describe(`GraphQLNonNegativeFloat`, () => {
             test(`int`, () => expect(GraphQLNonNegativeFloat.parseLiteral({
                 kind: Kind.INT,
                 value: 123
-            })).toEqual(123));
+            })).toEqual('123'));
 
             test(`float`, () => expect(GraphQLNonNegativeFloat.parseLiteral({
                 kind: Kind.FLOAT,
                 value: 123.123
-            })).toEqual(123.123));
+            })).toEqual('123.123'));
 
             test(`zero`, () => expect(GraphQLNonNegativeFloat.parseLiteral({
                 kind: Kind.INT,
                 value: 0
-            })).toEqual(0));
+            })).toEqual('0'));
         });
 
         describe(`invalid`, () => {

--- a/test/GraphQLNonNegativeInteger.test.js
+++ b/test/GraphQLNonNegativeInteger.test.js
@@ -1,7 +1,6 @@
 import {describe, expect, test} from "@jest/globals";
 import GraphQLNonNegativeInteger from "../src/scalars/GraphQLNonNegativeInteger";
 import {Kind} from "graphql";
-import BigNumber from "bignumber.js";
 
 describe(`GraphQLNonNegativeInteger`, () => {
 
@@ -66,22 +65,22 @@ describe(`GraphQLNonNegativeInteger`, () => {
             test(`int`, () => expect(GraphQLNonNegativeInteger.parseLiteral({
                 kind: Kind.STRING,
                 value: '123'
-            })).toEqual(new BigNumber(123)));
+            })).toEqual('123'));
 
             test(`int`, () => expect(GraphQLNonNegativeInteger.parseLiteral({
                 kind: Kind.INT,
                 value: 123
-            })).toEqual(new BigNumber(123)));
+            })).toEqual('123'));
 
             test(`large number`, () => expect(GraphQLNonNegativeInteger.parseLiteral({
                 kind: Kind.INT,
-                value: 123123123123123123
-            })).toEqual(new BigNumber(123123123123123123)));
+                value: '123123123123123123'
+            })).toEqual('123123123123123123'));
 
             test(`zero`, () => expect(GraphQLNonNegativeInteger.parseLiteral({
                 kind: Kind.INT,
                 value: 0
-            })).toEqual(new BigNumber(0)));
+            })).toEqual('0'));
         });
 
         describe(`invalid`, () => {

--- a/test/GraphQLNonPositiveFloat.test.js
+++ b/test/GraphQLNonPositiveFloat.test.js
@@ -11,17 +11,17 @@ describe(`GraphQLNonPositiveFloat`, () => {
             test(`int`, () => expect(GraphQLNonPositiveFloat.parseLiteral({
                 kind: Kind.INT,
                 value: -123
-            })).toEqual(-123));
+            })).toEqual('-123'));
 
             test(`float`, () => expect(GraphQLNonPositiveFloat.parseLiteral({
                 kind: Kind.FLOAT,
                 value: -123.123
-            })).toEqual(-123.123));
+            })).toEqual('-123.123'));
 
             test(`zero`, () => expect(GraphQLNonPositiveFloat.parseLiteral({
                 kind: Kind.INT,
                 value: 0
-            })).toEqual(0));
+            })).toEqual('0'));
         });
 
         describe(`invalid`, () => {

--- a/test/GraphQLNonPositiveInteger.test.js
+++ b/test/GraphQLNonPositiveInteger.test.js
@@ -1,7 +1,6 @@
 import {describe, expect, test} from "@jest/globals";
 import GraphQLNonPositiveInteger from "../src/scalars/GraphQLNonPositiveInteger";
 import {Kind} from "graphql";
-import BigNumber from "bignumber.js";
 
 describe(`GraphQLNonPositiveInteger`, () => {
 
@@ -66,17 +65,17 @@ describe(`GraphQLNonPositiveInteger`, () => {
             test(`string`, () => expect(GraphQLNonPositiveInteger.parseLiteral({
                 kind: Kind.STRING,
                 value: '-1000'
-            })).toEqual(new BigNumber(-1000)));
+            })).toEqual('-1000'));
 
             test(`int`, () => expect(GraphQLNonPositiveInteger.parseLiteral({
                 kind: Kind.INT,
                 value: -123
-            })).toEqual(new BigNumber(-123)));
+            })).toEqual('-123'));
 
             test(`zero`, () => expect(GraphQLNonPositiveInteger.parseLiteral({
                 kind: Kind.INT,
                 value: 0
-            })).toEqual(new BigNumber(0)));
+            })).toEqual('0'));
         });
 
         describe(`invalid`, () => {

--- a/test/GraphQLPositiveFloat.test.js
+++ b/test/GraphQLPositiveFloat.test.js
@@ -11,12 +11,12 @@ describe(`GraphQLPositiveFloat`, () => {
             test(`int`, () => expect(GraphQLPositiveFloat.parseLiteral({
                 kind: Kind.INT,
                 value: 123
-            })).toEqual(123));
+            })).toEqual('123'));
 
             test(`float`, () => expect(GraphQLPositiveFloat.parseLiteral({
                 kind: Kind.FLOAT,
                 value: 123.123
-            })).toEqual(123.123));
+            })).toEqual('123.123'));
         });
 
         describe(`invalid`, () => {

--- a/test/GraphQLPositiveInteger.test.js
+++ b/test/GraphQLPositiveInteger.test.js
@@ -1,7 +1,6 @@
 import {describe, expect, test} from "@jest/globals";
 import GraphQLPositiveInteger from "../src/scalars/GraphQLPositiveInteger";
 import {Kind} from "graphql";
-import BigNumber from "bignumber.js";
 
 describe(`GraphQLPositiveInteger`, () => {
 
@@ -67,12 +66,12 @@ describe(`GraphQLPositiveInteger`, () => {
             test(`string`, () => expect(GraphQLPositiveInteger.parseLiteral({
                 kind: Kind.STRING,
                 value: '123123'
-            })).toEqual(BigNumber(123123)));
+            })).toEqual('123123'));
 
             test(`integer`, () => expect(GraphQLPositiveInteger.parseLiteral({
                 kind: Kind.INT,
                 value: 123123
-            })).toEqual(BigNumber(123123)));
+            })).toEqual('123123'));
         });
 
         describe(`invalid`, () => {

--- a/test/time/GraphQLYear.test.js
+++ b/test/time/GraphQLYear.test.js
@@ -8,11 +8,11 @@ describe(`GraphQLYear`, () => {
 
         describe(`valid`, () => {
 
-            test(`date object`, () => expect(GraphQLYear.serialize(new Date('Wed Jun 10 2020 09:42:45 GMT+0300'))).toEqual(2020));
+            test(`date object`, () => expect(GraphQLYear.serialize(new Date('Wed Jun 10 2020 09:42:45 GMT+0300'))).toEqual('2020'));
 
-            test(`string`, () => expect(GraphQLYear.serialize('Wed Jun 10 2020 09:42:45 GMT+0300')).toEqual(2020));
+            test(`string`, () => expect(GraphQLYear.serialize('Wed Jun 10 2020 09:42:45 GMT+0300')).toEqual('2020'));
 
-            test(`string UTC format`, () => expect(GraphQLYear.serialize('Wed, 10 Jun 2020 06:54:06 GMT')).toEqual(2020));
+            test(`string UTC format`, () => expect(GraphQLYear.serialize('Wed, 10 Jun 2020 06:54:06 GMT')).toEqual('2020'));
 
         });
 

--- a/test/time/GraphQLYearMonth.test.js
+++ b/test/time/GraphQLYearMonth.test.js
@@ -8,11 +8,13 @@ describe(`GraphQLYearMonth`, () => {
 
         describe(`valid`, () => {
 
-            test(`date object`, () => expect(GraphQLYearMonth.serialize(new Date('Wed Jun 10 2020 09:42:45 GMT+0300'))).toEqual('2020-5'));
+            test(`date object`, () => expect(GraphQLYearMonth.serialize(new Date('Wed Jun 10 2020 09:42:45 GMT+0300'))).toEqual('2020-05'));
 
-            test(`string`, () => expect(GraphQLYearMonth.serialize('Wed Jun 10 2020 09:42:45 GMT+0300')).toEqual('2020-5'));
+            test(`string`, () => expect(GraphQLYearMonth.serialize('Wed Jun 10 2020 09:42:45 GMT+0300')).toEqual('2020-05'));
 
-            test(`string UTC format`, () => expect(GraphQLYearMonth.serialize('Wed, 10 Jun 2020 06:54:06 GMT')).toEqual('2020-5'));
+            test(`string UTC format`, () => expect(GraphQLYearMonth.serialize('Wed, 10 Jun 2020 06:54:06 GMT')).toEqual('2020-05'));
+
+            test(`month without leading zero`, () => expect(GraphQLYearMonth.serialize('Wed, 10 Nov 2020 06:54:06 GMT')).toEqual('2020-10'));
 
         });
 

--- a/test/unsigned/GraphQLUnsignedByte.test.js
+++ b/test/unsigned/GraphQLUnsignedByte.test.js
@@ -8,11 +8,11 @@ describe(`GraphQLUnsignedByte`, () => {
 
         describe(`valid`, () => {
 
-            test(`int`, () => expect(GraphQLUnsignedByte.serialize(100)).toEqual(100));
+            test(`int`, () => expect(GraphQLUnsignedByte.serialize(100)).toEqual('100'));
 
-            test(`string`, () => expect(GraphQLUnsignedByte.serialize('100')).toEqual(100));
+            test(`string`, () => expect(GraphQLUnsignedByte.serialize('100')).toEqual('100'));
 
-            test(`float`, () => expect(GraphQLUnsignedByte.serialize(100.11)).toEqual(100));
+            test(`float`, () => expect(GraphQLUnsignedByte.serialize(100.11)).toEqual('100'));
 
         });
 
@@ -35,11 +35,11 @@ describe(`GraphQLUnsignedByte`, () => {
 
         describe(`valid`, () => {
 
-            test(`int`, () => expect(GraphQLUnsignedByte.parseValue(100)).toEqual(100));
+            test(`int`, () => expect(GraphQLUnsignedByte.parseValue(100)).toEqual('100'));
 
-            test(`string`, () => expect(GraphQLUnsignedByte.parseValue('100')).toEqual(100));
+            test(`string`, () => expect(GraphQLUnsignedByte.parseValue('100')).toEqual('100'));
 
-            test(`float`, () => expect(GraphQLUnsignedByte.parseValue(100.11)).toEqual(100));
+            test(`float`, () => expect(GraphQLUnsignedByte.parseValue(100.11)).toEqual('100'));
 
         });
 
@@ -65,27 +65,27 @@ describe(`GraphQLUnsignedByte`, () => {
             test(`int`, () => expect(GraphQLUnsignedByte.parseLiteral({
                 kind: Kind.INT,
                 value: 100
-            })).toEqual(100));
+            })).toEqual('100'));
 
             test(`string`, () => expect(GraphQLUnsignedByte.parseLiteral({
                 kind: Kind.STRING,
                 value: 100
-            })).toEqual(100));
+            })).toEqual('100'));
 
             test(`float`, () => expect(GraphQLUnsignedByte.parseLiteral({
                 kind: Kind.STRING,
                 value: '100.12'
-            })).toEqual(100));
+            })).toEqual('100'));
 
             test(`max value`, () => expect(GraphQLUnsignedByte.parseLiteral({
                 kind: Kind.INT,
-                value: 256
-            })).toEqual(256));
+                value: 255
+            })).toEqual('255'));
 
             test(`zero`, () => expect(GraphQLUnsignedByte.parseLiteral({
                 kind: Kind.STRING,
                 value: '0'
-            })).toEqual(0));
+            })).toEqual('0'));
 
         });
 
@@ -108,7 +108,7 @@ describe(`GraphQLUnsignedByte`, () => {
 
             test(`over max value`, () => expect(() => GraphQLUnsignedByte.parseLiteral({
                 kind: Kind.INT,
-                value: 257
+                value: 256
             })).toThrow());
         });
     });

--- a/test/unsigned/GraphQLUnsignedInteger.test.js
+++ b/test/unsigned/GraphQLUnsignedInteger.test.js
@@ -8,11 +8,11 @@ describe(`GraphQLUnsignedInteger`, () => {
 
         describe(`valid`, () => {
 
-            test(`int`, () => expect(GraphQLUnsignedInteger.serialize(100)).toEqual(100));
+            test(`int`, () => expect(GraphQLUnsignedInteger.serialize(100)).toEqual('100'));
 
-            test(`string`, () => expect(GraphQLUnsignedInteger.serialize('100')).toEqual(100));
+            test(`string`, () => expect(GraphQLUnsignedInteger.serialize('100')).toEqual('100'));
 
-            test(`float`, () => expect(GraphQLUnsignedInteger.serialize(100.11)).toEqual(100));
+            test(`float`, () => expect(GraphQLUnsignedInteger.serialize(100.11)).toEqual('100'));
 
         });
 
@@ -35,11 +35,11 @@ describe(`GraphQLUnsignedInteger`, () => {
 
         describe(`valid`, () => {
 
-            test(`int`, () => expect(GraphQLUnsignedInteger.parseValue(100)).toEqual(100));
+            test(`int`, () => expect(GraphQLUnsignedInteger.parseValue(100)).toEqual('100'));
 
-            test(`string`, () => expect(GraphQLUnsignedInteger.parseValue('100')).toEqual(100));
+            test(`string`, () => expect(GraphQLUnsignedInteger.parseValue('100')).toEqual('100'));
 
-            test(`float`, () => expect(GraphQLUnsignedInteger.parseValue(100.11)).toEqual(100));
+            test(`float`, () => expect(GraphQLUnsignedInteger.parseValue(100.11)).toEqual('100'));
 
         });
 
@@ -65,27 +65,27 @@ describe(`GraphQLUnsignedInteger`, () => {
             test(`int`, () => expect(GraphQLUnsignedInteger.parseLiteral({
                 kind: Kind.INT,
                 value: 100
-            })).toEqual(100));
+            })).toEqual('100'));
 
             test(`string`, () => expect(GraphQLUnsignedInteger.parseLiteral({
                 kind: Kind.STRING,
                 value: 100
-            })).toEqual(100));
+            })).toEqual('100'));
 
             test(`float`, () => expect(GraphQLUnsignedInteger.parseLiteral({
                 kind: Kind.STRING,
                 value: '100.12'
-            })).toEqual(100));
+            })).toEqual('100'));
 
             test(`max value`, () => expect(GraphQLUnsignedInteger.parseLiteral({
                 kind: Kind.INT,
-                value: 4294967296
-            })).toEqual(4294967296));
+                value: 4294967295
+            })).toEqual('4294967295'));
 
             test(`zero`, () => expect(GraphQLUnsignedInteger.parseLiteral({
                 kind: Kind.STRING,
                 value: '0'
-            })).toEqual(0));
+            })).toEqual('0'));
 
         });
 
@@ -108,7 +108,7 @@ describe(`GraphQLUnsignedInteger`, () => {
 
             test(`over max value`, () => expect(() => GraphQLUnsignedInteger.parseLiteral({
                 kind: Kind.INT,
-                value: 4294967297
+                value: 4294967296
             })).toThrow());
 
         });

--- a/test/unsigned/GraphQLUnsignedLong.test.js
+++ b/test/unsigned/GraphQLUnsignedLong.test.js
@@ -1,7 +1,6 @@
 import {describe, expect, test} from "@jest/globals";
 import GraphQLUnsignedLong from "../../src/scalars/unsigned/GraphQLUnsignedLong";
 import {Kind} from "graphql";
-import BigNumber from "bignumber.js";
 
 describe(`GraphQLUnsignedLong`, () => {
 
@@ -66,27 +65,27 @@ describe(`GraphQLUnsignedLong`, () => {
             test(`int`, () => expect(GraphQLUnsignedLong.parseLiteral({
                 kind: Kind.INT,
                 value: 100
-            })).toEqual(new BigNumber(100)));
+            })).toEqual('100'));
 
             test(`string`, () => expect(GraphQLUnsignedLong.parseLiteral({
                 kind: Kind.STRING,
                 value: '100'
-            })).toEqual(new BigNumber(100)));
+            })).toEqual('100'));
 
             test(`float`, () => expect(GraphQLUnsignedLong.parseLiteral({
                 kind: Kind.STRING,
                 value: '100.12'
-            })).toEqual(new BigNumber(100)));
+            })).toEqual('100'));
 
             test(`max value`, () => expect(GraphQLUnsignedLong.parseLiteral({
                 kind: Kind.INT,
-                value: 18446744073709552000
-            })).toEqual(new BigNumber(18446744073709552000)));
+                value: '18446744073709551615'
+            })).toEqual('18446744073709551615'));
 
             test(`zero`, () => expect(GraphQLUnsignedLong.parseLiteral({
                 kind: Kind.STRING,
                 value: 0
-            })).toEqual(new BigNumber(0)));
+            })).toEqual('0'));
 
         });
 
@@ -105,6 +104,11 @@ describe(`GraphQLUnsignedLong`, () => {
             test(`negative int`, () => expect(() => GraphQLUnsignedLong.parseLiteral({
                 kind: Kind.INT,
                 value: -10
+            })).toThrow());
+
+            test(`max value edge`, () => expect(() => GraphQLUnsignedLong.parseLiteral({
+                kind: Kind.INT,
+                value: 18446744073709551616
             })).toThrow());
 
             test(`over max value`, () => expect(() => GraphQLUnsignedLong.parseLiteral({

--- a/test/unsigned/GraphQLUnsignedShort.test.js
+++ b/test/unsigned/GraphQLUnsignedShort.test.js
@@ -8,11 +8,11 @@ describe(`GraphQLUnsignedShort`, () => {
 
         describe(`valid`, () => {
 
-            test(`int`, () => expect(GraphQLUnsignedShort.serialize(100)).toEqual(100));
+            test(`int`, () => expect(GraphQLUnsignedShort.serialize(100)).toEqual('100'));
 
-            test(`string`, () => expect(GraphQLUnsignedShort.serialize('100')).toEqual(100));
+            test(`string`, () => expect(GraphQLUnsignedShort.serialize('100')).toEqual('100'));
 
-            test(`float`, () => expect(GraphQLUnsignedShort.serialize(100.11)).toEqual(100));
+            test(`float`, () => expect(GraphQLUnsignedShort.serialize(100.11)).toEqual('100'));
 
         });
 
@@ -35,11 +35,11 @@ describe(`GraphQLUnsignedShort`, () => {
 
         describe(`valid`, () => {
 
-            test(`int`, () => expect(GraphQLUnsignedShort.parseValue(100)).toEqual(100));
+            test(`int`, () => expect(GraphQLUnsignedShort.parseValue(100)).toEqual('100'));
 
-            test(`string`, () => expect(GraphQLUnsignedShort.parseValue('100')).toEqual(100));
+            test(`string`, () => expect(GraphQLUnsignedShort.parseValue('100')).toEqual('100'));
 
-            test(`float`, () => expect(GraphQLUnsignedShort.parseValue(100.11)).toEqual(100));
+            test(`float`, () => expect(GraphQLUnsignedShort.parseValue(100.11)).toEqual('100'));
 
         });
 
@@ -65,27 +65,27 @@ describe(`GraphQLUnsignedShort`, () => {
             test(`int`, () => expect(GraphQLUnsignedShort.parseLiteral({
                 kind: Kind.INT,
                 value: 100
-            })).toEqual(100));
+            })).toEqual('100'));
 
             test(`string`, () => expect(GraphQLUnsignedShort.parseLiteral({
                 kind: Kind.STRING,
                 value: 100
-            })).toEqual(100));
+            })).toEqual('100'));
 
             test(`float`, () => expect(GraphQLUnsignedShort.parseLiteral({
                 kind: Kind.STRING,
                 value: '100.12'
-            })).toEqual(100));
+            })).toEqual('100'));
 
             test(`max value`, () => expect(GraphQLUnsignedShort.parseLiteral({
                 kind: Kind.INT,
-                value: 65536
-            })).toEqual(65536));
+                value: 65535
+            })).toEqual('65535'));
 
             test(`zero`, () => expect(GraphQLUnsignedShort.parseLiteral({
                 kind: Kind.INT,
                 value: 0
-            })).toEqual(0));
+            })).toEqual('0'));
 
         });
 
@@ -108,7 +108,7 @@ describe(`GraphQLUnsignedShort`, () => {
 
             test(`over max value`, () => expect(() => GraphQLUnsignedShort.parseLiteral({
                 kind: Kind.INT,
-                value: 65537
+                value: 65536
             })).toThrow());
         });
     });


### PR DESCRIPTION
- Now all scalar types will return string representation of the numbers,
when they are serialized, parsed, validated, etc. This is done in order
to unify the way in which the platform and the current library work and
more specifically the handling of large numbers. As there are many
differences in the numbers boundaries in java, javascript and graphql,
it was decided that it is best just to return their string
representation and let the clients decide, how and what to do with the
received result.
- Added few missing validations in the unsigned scalars, where the value
was never checked, if it was in the max limit, when it was serialized or
parsed as value.
- Added few changes to the time scalars, more particularly to year and
yearMonth. The year is now returned as string, instead of number.
YearMonth now will return the month with leading zero, if it is a single
digit.
- Removed the usage of the bignumbers.js library as it was not needed
anymore and there were some issues with the rounding of the large
floating point numbers.
- Fixed the tests accordingly to the added changes and added couple of
cases to ensure proper behavior.

Signed-off-by: Antoniy Kunchev <antoniy.kunchev@ontotext.com>